### PR TITLE
remove dejiren topicData info after getCordovaIntent

### DIFF
--- a/src/android/IntentPlugin.java
+++ b/src/android/IntentPlugin.java
@@ -91,6 +91,8 @@ public class IntentPlugin extends CordovaPlugin {
 
         Intent intent = cordova.getActivity().getIntent();
         context.sendPluginResult(new PluginResult(PluginResult.Status.OK, getIntentJson(intent)));
+        // dejiren 専用 1回だけ取得して、topicDataを削除する
+        intent.removeExtra("topicData");
         return true;
     }
 


### PR DESCRIPTION
coldstart　した場合、通知情報を1回取得した後に、誤動作を防ぐため、dejirenのtopicData情報を削除する